### PR TITLE
fix: stabilise ces compute_z dtype

### DIFF
--- a/src/Urban_Amenities2/math/ces.py
+++ b/src/Urban_Amenities2/math/ces.py
@@ -47,15 +47,13 @@ def compute_z(
     accessibility: NDArray[np.float64],
     rho: float,
 ) -> NDArray[np.float64]:
-    product: NDArray[np.float64] = np.asarray(
-        np.maximum(quality * accessibility, 0.0), dtype=float
-    )
+    product = quality * accessibility
+    non_negative = np.maximum(product, 0.0)
+    product64 = non_negative.astype(np.float64)
     if abs(rho - 1.0) < _LINEAR_TOL:
-        return product
-    powered: NDArray[np.float64] = np.asarray(
-        np.power(np.clip(product, 0.0, None), rho), dtype=float
-    )
-    return powered
+        return product64
+    powered = np.power(product64, rho)
+    return powered.astype(np.float64)
 
 
 def _geometric_mean(product: NDArray[np.float64], axis: int) -> NDArray[np.float64]:

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -22,6 +22,15 @@ def test_ces_known_output() -> None:
     assert pytest.approx(result[0]) == 1.5
 
 
+def test_compute_z_returns_float64_and_non_negative() -> None:
+    quality = np.array([[0.8, 1.2], [0.0, 2.5]], dtype=np.float32)
+    accessibility = np.array([[0.5, 0.3], [1.5, 0.0]], dtype=np.float32)
+    result = compute_z(quality, accessibility, rho=0.7)
+    assert result.dtype == np.float64
+    assert result.shape == quality.shape
+    assert np.all(result >= 0.0)
+
+
 def test_ces_monotonicity() -> None:
     base_quality = np.array([[0.5, 0.5]])
     better_quality = np.array([[0.6, 0.5]])


### PR DESCRIPTION
## Summary
- ensure the CES compute_z kernel promotes non-negative products to float64 before exponentiation to avoid numba dtype errors
- add a regression test asserting the kernel preserves shape and non-negativity

## Testing
- pytest --no-cov tests/test_math.py::test_compute_z_returns_float64_and_non_negative -q

------
https://chatgpt.com/codex/tasks/task_e_68dfc2ec83fc832f87590506908c59c9