### PR TITLE
Add UI module regression tests

### DIFF
--- a/tests/ui/conftest.py
+++ b/tests/ui/conftest.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from types import SimpleNamespace
+from typing import Iterable
+
+import pandas as pd
+import pytest
+
+from Urban_Amenities2.ui import data_loader, export, hex_selection, hexes
+
+
+@dataclass
+class FakeShape:
+    coordinates: list[tuple[float, float]]
+
+    @property
+    def is_empty(self) -> bool:
+        return not self.coordinates
+
+    def simplify(self, _tolerance: float, preserve_topology: bool = True) -> "FakeShape":
+        return self
+
+
+class FakeH3:
+    """Minimal stand-in for the ``h3`` module used in UI utilities."""
+
+    def __init__(self) -> None:
+        self.boundary_calls: list[str] = []
+        self.centroid_calls: list[str] = []
+        self.parent_requests: list[tuple[str, int]] = []
+
+    @staticmethod
+    def _base_coords(hex_id: str) -> tuple[float, float]:
+        seed = sum(ord(ch) for ch in hex_id)
+        lon = -105.0 + (seed % 10) * 0.01
+        lat = 39.0 + ((seed // 10) % 10) * 0.01
+        return lon, lat
+
+    def cell_to_boundary(self, hex_id: str) -> list[list[float]]:
+        self.boundary_calls.append(hex_id)
+        lon, lat = self._base_coords(hex_id)
+        return [
+            [lat, lon],
+            [lat + 0.01, lon],
+            [lat + 0.01, lon + 0.01],
+            [lat, lon + 0.01],
+        ]
+
+    def cell_to_latlng(self, hex_id: str) -> tuple[float, float]:
+        self.centroid_calls.append(hex_id)
+        lon, lat = self._base_coords(hex_id)
+        return lat + 0.005, lon + 0.005
+
+    @staticmethod
+    def get_resolution(_hex_id: str) -> int:
+        return 9
+
+    def cell_to_parent(self, hex_id: str, resolution: int) -> str:
+        self.parent_requests.append((hex_id, resolution))
+        return f"{hex_id[:8]}_r{resolution}"
+
+    def grid_disk(self, hex_id: str, k: int) -> list[str]:
+        return [hex_id, *[f"{hex_id}-n{i}" for i in range(1, k + 1)]]
+
+    def k_ring(self, hex_id: str, k: int = 1) -> list[str]:
+        return self.grid_disk(hex_id, k)
+
+
+@pytest.fixture
+def fake_h3(monkeypatch: pytest.MonkeyPatch) -> FakeH3:
+    """Provide a shared fake H3 module for UI tests."""
+
+    stub = FakeH3()
+
+    monkeypatch.setattr(hexes, "_load_h3", lambda: stub)
+    monkeypatch.setattr(hex_selection, "_import_h3", lambda: stub)
+    monkeypatch.setattr(data_loader, "_import_h3", lambda: stub)
+    monkeypatch.setattr(export, "_h3", lambda: stub)
+
+    yield stub
+
+    hexes._hex_boundary_geojson.cache_clear()
+    hexes._hex_boundary_wkt.cache_clear()
+    hexes._hex_centroid.cache_clear()
+
+
+@pytest.fixture
+def fake_shapely(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Patch shapely helpers used by the data loader to avoid real dependency."""
+
+    def _parse_wkt(payload: str) -> FakeShape:
+        inner = payload.strip().removeprefix("POLYGON((").removesuffix("))")
+        coordinates: list[tuple[float, float]] = []
+        for part in inner.split(","):
+            part = part.strip()
+            if not part:
+                continue
+            lon_str, lat_str = part.split()
+            coordinates.append((float(lon_str), float(lat_str)))
+        return FakeShape(coordinates)
+
+    def _mapping(shape: FakeShape) -> dict[str, object]:
+        return {
+            "type": "Polygon",
+            "coordinates": [[list(coord) for coord in shape.coordinates]],
+        }
+
+    def _unary_union(shapes: Iterable[FakeShape]) -> FakeShape:
+        shapes = list(shapes)
+        if not shapes:
+            return FakeShape([])
+        return FakeShape(list(shapes[0].coordinates))
+
+    monkeypatch.setattr(
+        data_loader,
+        "_import_shapely_modules",
+        lambda: (SimpleNamespace(loads=_parse_wkt), _mapping, _unary_union),
+    )
+
+
+@pytest.fixture
+def sample_scores() -> pd.DataFrame:
+    """Create a deterministic scores DataFrame for selection tests."""
+
+    data = {
+        "hex_id": ["abc123", "def456", "ghi789"],
+        "aucs": [75.0, 80.0, 90.0],
+        "EA": [70.0, 65.0, 85.0],
+        "state": ["CO", "CO", "UT"],
+        "metro": ["Denver", "Boulder", "Salt Lake City"],
+        "county": ["Denver", "Boulder", "Salt Lake"],
+        "top_amenities": [
+            [{"name": "Library", "category": "Education", "score": 0.95}],
+            [],
+            [{"name": "Cafe", "category": "Food", "score": 0.8}],
+        ],
+        "top_modes": [
+            {"transit": 0.4, "walk": 0.2},
+            {"drive": 0.6},
+            {"bike": 0.3},
+        ],
+    }
+    return pd.DataFrame(data)

--- a/tests/ui/test_callbacks_helpers.py
+++ b/tests/ui/test_callbacks_helpers.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from Urban_Amenities2.ui.callbacks import (
+    _extract_viewport_bounds,
+    _normalise_filters,
+    _normalise_overlays,
+    _resolution_for_zoom,
+)
+
+
+def test_normalise_filters_and_overlays() -> None:
+    assert _normalise_filters(None) == []
+    assert _normalise_filters("CO") == ["CO"]
+    assert _normalise_filters(["CO", "", "UT"]) == ["CO", "UT"]
+
+    overlays = _normalise_overlays(["states", "unknown", "parks"])
+    assert overlays == ["states", "parks"]
+
+
+def test_resolution_for_zoom_thresholds() -> None:
+    assert _resolution_for_zoom(None) == 8
+    assert _resolution_for_zoom(4.5) == 6
+    assert _resolution_for_zoom(7.2) == 7
+    assert _resolution_for_zoom(10.5) == 8
+    assert _resolution_for_zoom(12.0) == 9
+
+
+def test_extract_viewport_bounds_from_coordinates() -> None:
+    relayout = {
+        "mapbox._derived": {
+            "coordinates": [
+                [[-105.0, 39.7], [-104.9, 39.7], [-104.9, 39.8], [-105.0, 39.8]],
+            ]
+        }
+    }
+    bounds = _extract_viewport_bounds(relayout, None)
+    assert bounds == (-105.0, 39.7, -104.9, 39.8)
+
+
+def test_extract_viewport_bounds_from_center_zoom() -> None:
+    relayout = {
+        "mapbox.center.lon": -105.0,
+        "mapbox.center.lat": 39.7,
+        "mapbox.zoom": 8.0,
+    }
+    fallback = (-106.0, 38.5, -104.0, 40.5)
+    bounds = _extract_viewport_bounds(relayout, fallback)
+    assert bounds is not None
+    assert bounds[0] < relayout["mapbox.center.lon"]
+    assert bounds[2] > relayout["mapbox.center.lon"]
+
+
+def test_extract_viewport_bounds_invalid_returns_fallback() -> None:
+    fallback = (-1.0, -1.0, 1.0, 1.0)
+    assert _extract_viewport_bounds({}, fallback) == fallback
+    assert _extract_viewport_bounds(None, fallback) == fallback

--- a/tests/ui/test_data_context.py
+++ b/tests/ui/test_data_context.py
@@ -1,0 +1,258 @@
+from __future__ import annotations
+
+import json
+import os
+import time
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from Urban_Amenities2.ui import data_loader
+from Urban_Amenities2.ui.config import UISettings
+from Urban_Amenities2.ui.data_loader import DataContext
+
+
+def _settings(data_path: Path) -> UISettings:
+    return UISettings(
+        host="127.0.0.1",
+        port=8050,
+        debug=False,
+        secret_key="test",
+        mapbox_token=None,
+        cors_origins=[],
+        enable_cors=False,
+        data_path=data_path,
+        log_level="INFO",
+        title="UI Test",
+        reload_interval_seconds=30,
+        hex_resolutions=[7, 8, 9],
+        summary_percentiles=[5, 50, 95],
+    )
+
+
+def _build_scores(hex_ids: list[str], aucs: list[float]) -> pd.DataFrame:
+    states = ["CO" if idx % 2 == 0 else "UT" for idx in range(len(hex_ids))]
+    frame = pd.DataFrame(
+        {
+            "hex_id": hex_ids,
+            "aucs": aucs,
+            "EA": [value - 1 for value in aucs],
+            "LCA": [value - 2 for value in aucs],
+            "MUHAA": [value - 3 for value in aucs],
+            "JEA": [value - 4 for value in aucs],
+            "MORR": [value - 5 for value in aucs],
+            "CTE": [value - 6 for value in aucs],
+            "SOU": [value - 7 for value in aucs],
+        }
+    )
+    return frame
+
+
+def _parquet_frames(data_dir: Path) -> dict[str, pd.DataFrame]:
+    older_scores = data_dir / "20240101_scores.parquet"
+    newer_scores = data_dir / "20240201_scores.parquet"
+    older_scores.touch()
+    newer_scores.touch()
+    now = time.time()
+    os.utime(older_scores, (now - 60, now - 60))
+    os.utime(newer_scores, (now, now))
+    older_meta = data_dir / "20240101_metadata.parquet"
+    older_meta.touch()
+    fallback_meta = data_dir / "metadata.parquet"
+    fallback_meta.touch()
+
+    frames: dict[str, pd.DataFrame] = {
+        str(older_scores): _build_scores(["abc123", "def456"], [70.0, 60.0]),
+        str(newer_scores): _build_scores(["abc123", "ghi789"], [75.0, 65.0]),
+        str(older_meta): pd.DataFrame(
+            {
+                "hex_id": ["abc123", "def456"],
+                "state": ["CO", "UT"],
+                "metro": ["Denver", "Salt Lake"],
+                "county": ["Denver", "Salt Lake"],
+            }
+        ),
+        str(fallback_meta): pd.DataFrame(
+            {
+                "hex_id": ["abc123", "ghi789"],
+                "state": ["CO", "UT"],
+                "metro": ["Denver", "Salt Lake"],
+                "county": ["Denver", "Salt Lake"],
+            }
+        ),
+    }
+    return frames
+
+
+@pytest.fixture
+def ui_dataset(tmp_path: Path) -> tuple[Path, dict[str, pd.DataFrame]]:
+    data_dir = tmp_path / "ui"
+    data_dir.mkdir()
+    overlays = data_dir / "overlays"
+    overlays.mkdir()
+    (overlays / "transit_lines.geojson").write_text(
+        json.dumps(
+            {
+                "type": "FeatureCollection",
+                "features": [
+                    {
+                        "type": "Feature",
+                        "geometry": {
+                            "type": "LineString",
+                            "coordinates": [[-105.0, 39.7], [-104.9, 39.8]],
+                        },
+                        "properties": {"label": "Line"},
+                    }
+                ],
+            }
+        )
+    )
+    frames = _parquet_frames(data_dir)
+    return data_dir, frames
+
+
+def test_data_context_version_switching(
+    ui_dataset: tuple[Path, dict[str, pd.DataFrame]],
+    monkeypatch: pytest.MonkeyPatch,
+    fake_h3,
+    fake_shapely,
+) -> None:
+    data_dir, frames = ui_dataset
+
+    def fake_parquet_loader(self: DataContext, path: Path, columns=None):
+        key = str(path)
+        frame = frames[key]
+        result = frame.copy()
+        if columns:
+            cols = [column for column in columns if column in result.columns]
+            result = result.loc[:, cols]
+        if "hex_id" in result.columns:
+            result["hex_id"] = result["hex_id"].astype("category")
+        return result
+
+    monkeypatch.setattr(DataContext, "_load_parquet", fake_parquet_loader)
+
+    shapely_wkt, mapping, unary_union = data_loader._import_shapely_modules()
+    assert hasattr(shapely_wkt, "loads")
+    assert callable(mapping)
+    assert callable(unary_union)
+
+    context = DataContext.from_settings(_settings(data_dir))
+    assert context.version is not None
+    assert context.version.identifier == "20240201"
+    available = {version.identifier for version in context.available_versions()}
+    assert available == {"20240201", "20240101"}
+
+    # Overlays use patched shapely helpers and external overlay files.
+    states = context.get_overlay("states")
+    assert states["features"]
+    assert {feature["properties"]["label"] for feature in states["features"]} == {"CO", "UT"}
+
+    assert context.load_version("20240101") is True
+    assert context.version is not None and context.version.identifier == "20240101"
+    assert context.scores["aucs"].tolist() == [70.0, 60.0]
+
+    # Aggregation cache resets when switching versions.
+    context.frame_for_resolution(7, columns=["aucs"])
+    assert context._aggregation_cache
+    context.load_version("20240201")
+    assert context._aggregation_cache == {}
+
+
+def test_data_context_viewport_and_exports(
+    ui_dataset: tuple[Path, dict[str, pd.DataFrame]],
+    monkeypatch: pytest.MonkeyPatch,
+    fake_h3,
+    fake_shapely,
+    tmp_path: Path,
+) -> None:
+    data_dir, frames = ui_dataset
+
+    def fake_parquet_loader(self: DataContext, path: Path, columns=None):
+        frame = frames[str(path)].copy()
+        if columns:
+            cols = [column for column in columns if column in frame.columns]
+            frame = frame.loc[:, cols]
+        if "hex_id" in frame.columns:
+            frame["hex_id"] = frame["hex_id"].astype("category")
+        return frame
+
+    monkeypatch.setattr(DataContext, "_load_parquet", fake_parquet_loader)
+    context = DataContext.from_settings(_settings(data_dir))
+
+    base_resolution = context.base_resolution
+    assert base_resolution == 9
+    high_res = context.frame_for_resolution(base_resolution, columns=["aucs", "EA"])
+    assert set(high_res.columns) >= {"hex_id", "aucs", "EA"}
+
+    coarse = context.frame_for_resolution(7, columns=["aucs"])
+    assert {"hex_id", "aucs", "count"}.issubset(coarse.columns)
+
+    repeat = context.frame_for_resolution(7, columns=["aucs"])
+    assert repeat.equals(coarse)
+    assert repeat is not coarse  # cached copy returned
+
+    first = context.geometries.iloc[0]
+    delta = 0.0001
+    bounds = (
+        float(first["centroid_lon"]) - delta,
+        float(first["centroid_lat"]) - delta,
+        float(first["centroid_lon"]) + delta,
+        float(first["centroid_lat"]) + delta,
+    )
+
+    trimmed = context.apply_viewport(high_res, base_resolution, bounds)
+    assert len(trimmed) >= 1
+    assert set(trimmed["hex_id"]) <= set(high_res["hex_id"])  # filtered subset
+
+    ids = context.ids_in_viewport(bounds, resolution=base_resolution)
+    assert ids and all(isinstance(item, str) for item in ids)
+
+    attached = context.attach_geometries(high_res)
+    assert {"centroid_lat", "centroid_lon"}.issubset(attached.columns)
+
+    index = context.get_hex_index(7)
+    assert index
+
+    subset = context.load_subset(["hex_id", "aucs", "aucs"])
+    assert list(subset.columns) == ["hex_id", "aucs"]
+
+    geojson_path = tmp_path / "export.geojson"
+    context.export_geojson(geojson_path)
+    payload = json.loads(geojson_path.read_text())
+    assert payload["features"]
+
+    csv_path = tmp_path / "export.csv"
+    context.export_csv(csv_path)
+    assert csv_path.exists()
+
+
+def test_data_context_handles_missing_shapely(
+    ui_dataset: tuple[Path, dict[str, pd.DataFrame]],
+    monkeypatch: pytest.MonkeyPatch,
+    fake_h3,
+) -> None:
+    data_dir, frames = ui_dataset
+
+    def fake_parquet_loader(self: DataContext, path: Path, columns=None):
+        frame = frames[str(path)].copy()
+        if columns:
+            cols = [column for column in columns if column in frame.columns]
+            frame = frame.loc[:, cols]
+        if "hex_id" in frame.columns:
+            frame["hex_id"] = frame["hex_id"].astype("category")
+        return frame
+
+    monkeypatch.setattr(DataContext, "_load_parquet", fake_parquet_loader)
+
+    from Urban_Amenities2.ui import data_loader as module
+
+    def raise_modules() -> None:
+        raise ImportError("missing shapely")
+
+    monkeypatch.setattr(module, "_import_shapely_modules", raise_modules)
+
+    context = DataContext.from_settings(_settings(data_dir))
+    context.rebuild_overlays(force=True)
+    assert context.get_overlay("states")["features"] == []

--- a/tests/ui/test_hex_selection.py
+++ b/tests/ui/test_hex_selection.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from Urban_Amenities2.ui.hex_selection import HexDetails, HexSelector
+
+
+def test_hex_details_from_row(sample_scores: pd.DataFrame) -> None:
+    row = sample_scores.iloc[0]
+    details = HexDetails.from_row(row)
+
+    assert details.hex_id == row["hex_id"]
+    assert details.state == "CO"
+    assert details.aucs == pytest.approx(75.0)
+    assert details.top_amenities[0]["name"] == "Library"
+    assert details.top_modes["transit"] == pytest.approx(0.4)
+
+
+def test_hex_selector_selection_flow(sample_scores: pd.DataFrame) -> None:
+    selector = HexSelector(sample_scores)
+    selector.max_selection = 2
+
+    assert selector.select_hex("abc123") is True
+    assert selector.select_hex("abc123") is True  # duplicate allowed, no change
+    assert selector.select_hex("def456") is True
+    assert selector.select_hex("ghi789") is False  # limit reached
+    assert selector.selected_hexes == ["abc123", "def456"]
+
+    selector.deselect_hex("abc123")
+    assert selector.selected_hexes == ["def456"]
+
+    selector.clear_selection()
+    assert selector.selected_hexes == []
+
+
+def test_hex_selector_get_details_and_neighbors(
+    sample_scores: pd.DataFrame, fake_h3
+) -> None:
+    selector = HexSelector(sample_scores)
+    selector.select_hex("abc123")
+
+    details = selector.get_details("abc123")
+    assert isinstance(details, HexDetails)
+    assert details.metro == "Denver"
+
+    assert selector.get_details("missing") is None
+
+    neighbors = selector.get_neighbors("abc123", k=2)
+    # Fake H3 returns the id plus two derived neighbours; only ids in the dataframe remain.
+    assert neighbors.equals(sample_scores[sample_scores["hex_id"] == "abc123"]) is True
+
+
+def test_hex_selector_comparison_data(sample_scores: pd.DataFrame) -> None:
+    selector = HexSelector(sample_scores)
+    selector.select_hex("abc123")
+    selector.select_hex("def456")
+
+    comparison = selector.get_comparison_data()
+    assert list(comparison["hex_id"]) == ["abc123", "def456"]
+
+    selector.clear_selection()
+    empty = selector.get_comparison_data()
+    assert empty.empty

--- a/tests/ui/test_hexes.py
+++ b/tests/ui/test_hexes.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from Urban_Amenities2.ui import hexes
+
+
+@pytest.mark.usefixtures("fake_h3")
+def test_hex_geometry_helpers_cache(fake_h3) -> None:
+    hex_id = "abc123"
+    feature = hexes.hex_to_geojson(hex_id)
+    assert feature["type"] == "Polygon"
+    assert len(feature["coordinates"][0]) == 5  # closed ring
+
+    assert fake_h3.boundary_calls.count(hex_id) == 1
+
+    # Cached calls should not trigger additional boundary lookups for the same helper.
+    hexes.hex_to_geojson(hex_id)
+    assert fake_h3.boundary_calls.count(hex_id) == 1
+
+    hexes.hex_to_wkt(hex_id)
+    assert fake_h3.boundary_calls.count(hex_id) == 2
+
+    _ = hexes.hex_centroid(hex_id)
+
+
+@pytest.mark.usefixtures("fake_h3")
+def test_hex_geometry_cache_and_validation(fake_h3) -> None:
+    cache = hexes.HexGeometryCache()
+    ids = ["abc123", "def456"]
+    frame = cache.ensure_geometries(ids)
+    assert set(frame.columns) >= {
+        "hex_id",
+        "geometry",
+        "geometry_wkt",
+        "centroid_lon",
+        "centroid_lat",
+        "resolution",
+    }
+    assert len(frame) == 2
+
+    # Second call uses cached values.
+    initial_calls = fake_h3.boundary_calls.count("abc123")
+    cache.ensure_geometries(ids)
+    assert fake_h3.boundary_calls.count("abc123") == initial_calls
+
+    cache.validate(ids)
+    with pytest.raises(ValueError):
+        cache.validate(["missing"])
+
+
+@pytest.mark.usefixtures("fake_h3")
+def test_build_hex_index(fake_h3) -> None:
+    geometries = pd.DataFrame(
+        {
+            "hex_id": ["abc123", "def456", "ghi789"],
+            "resolution": [9, 9, 9],
+        }
+    )
+    index = hexes.build_hex_index(geometries, resolution=8)
+    assert index
+    for parent, children in index.items():
+        assert parent.endswith("_r8")
+        assert all(child in geometries["hex_id"].values for child in children)
+
+
+@pytest.mark.usefixtures("fake_h3")
+def test_hex_spatial_index_bbox_fallback(fake_h3) -> None:
+    cache = hexes.HexGeometryCache()
+    frame = cache.ensure_geometries(["abc123", "def456"])
+    index = hexes.HexSpatialIndex(frame)
+    index._tree = None
+    index._box = None
+    lon_min = float(frame["centroid_lon"].min()) - 0.001
+    lat_min = float(frame["centroid_lat"].min()) - 0.001
+    lon_max = float(frame["centroid_lon"].max()) + 0.001
+    lat_max = float(frame["centroid_lat"].max()) + 0.001
+    matches = index.query_bbox(lon_min, lat_min, lon_max, lat_max)
+    assert set(matches) == set(frame["hex_id"].astype(str))
+
+    neighbours = index.neighbours("abc123", k=1)
+    assert "abc123" in neighbours

--- a/tests/ui/test_layers.py
+++ b/tests/ui/test_layers.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from typing import Mapping
+
+import pytest
+
+from Urban_Amenities2.ui import layers
+
+
+class StubContext:
+    def __init__(self, overlays: Mapping[str, Mapping[str, object]]) -> None:
+        self._overlays = overlays
+
+    def get_overlay(self, key: str) -> Mapping[str, object]:
+        return self._overlays.get(key, {"type": "FeatureCollection", "features": []})
+
+
+def _feature_collection(feature: Mapping[str, object]) -> Mapping[str, object]:
+    return {"type": "FeatureCollection", "features": [dict(feature)]}
+
+
+def test_basemap_helpers() -> None:
+    options = layers.basemap_options()
+    values = {option["value"] for option in options}
+    assert "mapbox://styles/mapbox/streets-v11" in values
+
+    resolved = layers.resolve_basemap_style("carto-positron")
+    assert resolved == "carto-positron"
+    assert layers.resolve_basemap_style("unknown") == "mapbox://styles/mapbox/streets-v11"
+
+    attribution = layers.basemap_attribution("carto-positron")
+    assert "Carto" in attribution
+
+
+def test_build_overlay_payload_with_selected_layers() -> None:
+    overlays_map = {
+        "states": _feature_collection(
+            {
+                "type": "Feature",
+                "geometry": {
+                    "type": "Polygon",
+                    "coordinates": [[[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0], [0.0, 0.0]]],
+                },
+                "properties": {"label": "CO"},
+            }
+        ),
+        "transit_lines": _feature_collection(
+            {
+                "type": "Feature",
+                "geometry": {
+                    "type": "LineString",
+                    "coordinates": [[-105.0, 39.7], [-104.9, 39.8]],
+                },
+                "properties": {"label": "Line"},
+            }
+        ),
+        "parks": _feature_collection(
+            {
+                "type": "Feature",
+                "geometry": {
+                    "type": "Polygon",
+                    "coordinates": [[[0.0, 0.0], [0.5, 0.0], [0.5, 0.5], [0.0, 0.5], [0.0, 0.0]]],
+                },
+                "properties": {"label": "Park"},
+            }
+        ),
+    }
+    context = StubContext(overlays_map)
+
+    payload = layers.build_overlay_payload(
+        ["states", "transit_lines", "parks", "city_labels"],
+        context,
+        opacity=0.4,
+    )
+
+    assert payload.layers
+    assert any(layer["type"] == "fill" for layer in payload.layers)
+    assert any(layer["type"] == "line" for layer in payload.layers)
+    assert payload.traces  # city_labels adds a Scattermapbox trace
+
+
+@pytest.mark.parametrize(
+    "selection",
+    [[], ["unknown"]],
+)
+def test_build_overlay_payload_without_matches(selection: list[str]) -> None:
+    context = StubContext({})
+    payload = layers.build_overlay_payload(selection, context)
+    assert payload.layers == []
+    assert payload.traces == []

--- a/tests/ui/test_performance.py
+++ b/tests/ui/test_performance.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import pytest
+
+from Urban_Amenities2.ui import performance
+
+
+class FakeTime:
+    def __init__(self) -> None:
+        self._calls = 0
+
+    def perf_counter(self) -> float:
+        value = self._calls * 0.05
+        self._calls += 1
+        return value
+
+
+def test_timer_logs_elapsed_time(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    fake_time = FakeTime()
+    monkeypatch.setattr(performance, "time", fake_time)
+
+    with performance.timer("load-data"):
+        pass
+
+    captured = capsys.readouterr()
+    assert "operation_timed" in captured.out
+
+
+def test_profile_function_logs(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    fake_time = FakeTime()
+    monkeypatch.setattr(performance, "time", fake_time)
+
+    @performance.profile_function
+    def add(a: int, b: int) -> int:
+        return a + b
+
+    assert add(1, 2) == 3
+
+    captured = capsys.readouterr()
+    assert "function_profiled" in captured.out
+
+
+def test_performance_monitor_statistics() -> None:
+    monitor = performance.PerformanceMonitor()
+    for value in [10.0, 20.0, 30.0]:
+        monitor.record("load", value)
+
+    stats = monitor.get_stats("load")
+    assert stats is not None
+    assert stats["min"] == pytest.approx(10.0)
+    assert stats["max"] == pytest.approx(30.0)
+    assert stats["mean"] == pytest.approx(20.0)
+    assert stats["count"] == 3
+
+    assert monitor.get_stats("missing") is None
+    all_stats = monitor.get_all_stats()
+    assert "load" in all_stats


### PR DESCRIPTION
## Summary
- add shared UI fixtures with fake H3 and shapely helpers for deterministic UI testing
- exercise hex selection, geometry cache, data context workflows, overlay payloads, callback helpers, and performance utilities with new unit tests

## Testing
- PYTEST_ADDOPTS="--no-cov" PYTEST_DISABLE_COVERAGE_CHECKS=1 python -m pytest tests/ui/test_hex_selection.py -q
- PYTEST_ADDOPTS="--no-cov" PYTEST_DISABLE_COVERAGE_CHECKS=1 python -m pytest tests/ui/test_hexes.py -q
- PYTEST_ADDOPTS="--no-cov" PYTEST_DISABLE_COVERAGE_CHECKS=1 python -m pytest tests/ui/test_data_context.py -q
- PYTEST_ADDOPTS="--no-cov" PYTEST_DISABLE_COVERAGE_CHECKS=1 python -m pytest tests/ui/test_layers.py -q
- PYTEST_ADDOPTS="--no-cov" PYTEST_DISABLE_COVERAGE_CHECKS=1 python -m pytest tests/ui/test_callbacks_helpers.py -q
- PYTEST_ADDOPTS="--no-cov" PYTEST_DISABLE_COVERAGE_CHECKS=1 python -m pytest tests/ui/test_performance.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e03563619c832fbd91d6e125706ded