### PR TITLE
Add protocols to enrichment test stubs

### DIFF
--- a/openspec/changes/fix-test-type-safety/tasks.md
+++ b/openspec/changes/fix-test-type-safety/tasks.md
@@ -61,16 +61,16 @@
 
 ## 3. Stub Type Protocol Compliance (Medium Priority)
 
-- [ ] 3.1 **Create protocol definitions in tests/io/protocols.py**
-  - [ ] Define `SessionProtocol` for HTTP client stubs
-  - [ ] Define `WikidataClientProtocol` with `query` method signature
-  - [ ] Define `WikipediaClientProtocol` with `get_pageviews` signature
-  - [ ] Define `RateLimiterProtocol` and `CircuitBreakerProtocol`
+- [x] 3.1 **Create protocol definitions in tests/io/protocols.py**
+  - [x] Define `SessionProtocol` for HTTP client stubs
+  - [x] Define `WikidataClientProtocol` with `query` method signature
+  - [x] Define `WikipediaClientProtocol` with `get_pageviews` signature
+  - [x] Define `RateLimiterProtocol` and `CircuitBreakerProtocol`
 
-- [ ] 3.2 **Update StubSession to implement SessionProtocol**
-  - [ ] Add `request`, `get`, `post` method signatures to match `requests.Session`
-  - [ ] Implement `response` property for recording/playback
-  - [ ] Add type hints to `queue_response` method
+- [x] 3.2 **Update StubSession to implement SessionProtocol**
+  - [x] Add `request`, `get`, `post` method signatures to match `requests.Session`
+  - [x] Implement `response` property for recording/playback
+  - [x] Add type hints to `queue_response` method
 
 - [ ] 3.3 **Update WikidataClient stubs in tests/test_data_ingestion.py**
   - [ ] Make `StubClient` (line 335) implement `WikidataClientProtocol`
@@ -78,11 +78,11 @@
   - [ ] Make `RecordingClient` implement `WikidataClientProtocol`
   - [ ] Add explicit return types (`dict[str, Any]` vs `dict`)
 
-- [ ] 3.4 **Update WikipediaClient stubs in tests/io/enrichment/test_wikipedia.py**
-  - [ ] Fix `_StubSession` (line 389) to match `Session` protocol
-  - [ ] Fix `_StubRateLimiter` (line 390) to match `RateLimiter` interface
-  - [ ] Fix `_StubCircuitBreaker` (line 391) to match `CircuitBreaker` interface
-  - [ ] Add `CircuitBreaker` to explicit exports in wikipedia module (line 111)
+- [x] 3.4 **Update WikipediaClient stubs in tests/io/enrichment/test_wikipedia.py**
+  - [x] Fix `_StubSession` (line 389) to match `Session` protocol
+  - [x] Fix `_StubRateLimiter` (line 390) to match `RateLimiter` interface
+  - [x] Fix `_StubCircuitBreaker` (line 391) to match `CircuitBreaker` interface
+  - [x] Add `CircuitBreaker` to explicit exports in wikipedia module (line 111)
 
 - [ ] 3.5 **Update routing test stubs in tests/test_routing.py**
   - [ ] Make `StubSession` (lines 151, 156, 172, 177, 181) implement `SessionProtocol`

--- a/src/Urban_Amenities2/utils/resilience.py
+++ b/src/Urban_Amenities2/utils/resilience.py
@@ -7,17 +7,33 @@ import time
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from threading import Lock
-from typing import TypeVar
+from typing import Protocol, TypeVar
 
 __all__ = [
     "CircuitBreaker",
+    "CircuitBreakerProtocol",
     "CircuitBreakerOpenError",
     "RateLimiter",
+    "RateLimiterProtocol",
     "retry_with_backoff",
 ]
 
 
 T = TypeVar("T")
+
+
+class RateLimiterProtocol(Protocol):
+    """Structural protocol for rate limiter implementations used in tests."""
+
+    def acquire(self) -> float:
+        """Acquire permission to execute an operation, returning wait time."""
+
+
+class CircuitBreakerProtocol(Protocol):
+    """Structural protocol for circuit breaker implementations used in tests."""
+
+    def call(self, func: Callable[[], T]) -> T:
+        """Execute ``func`` applying circuit breaker semantics."""
 
 
 class RateLimiter:

--- a/tests/io/protocols.py
+++ b/tests/io/protocols.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from typing import Any, Protocol
+
+import pandas as pd
+
+from Urban_Amenities2.io.enrichment.wikipedia import ResponseProtocol, SessionProtocol
+from Urban_Amenities2.utils.resilience import CircuitBreakerProtocol, RateLimiterProtocol
+
+__all__ = [
+    "CircuitBreakerProtocol",
+    "RateLimiterProtocol",
+    "ResponseProtocol",
+    "SessionProtocol",
+    "WikipediaClientProtocol",
+    "WikidataClientProtocol",
+]
+
+
+class WikipediaClientProtocol(Protocol):
+    """Protocol describing the subset of :class:`WikipediaClient` used in tests."""
+
+    def fetch(self, title: str, *, months: int = ...) -> pd.DataFrame:
+        ...
+
+
+class WikidataClientProtocol(Protocol):
+    """Protocol describing the Wikidata client interface used in tests."""
+
+    def query(self, sparql: str) -> dict[str, Any]:
+        ...


### PR DESCRIPTION
## Summary
- add shared protocols for Wikipedia and Wikidata test doubles and mark related OpenSpec tasks complete
- expose HTTP and resilience protocols in the Wikipedia client and resilience utilities for structural typing
- update enrichment tests and shared StubSession helper to satisfy the new protocols while removing ad-hoc ignores

## Testing
- pytest tests/io/enrichment/test_wikipedia.py tests/io/enrichment/test_wikidata.py

------
https://chatgpt.com/codex/tasks/task_e_68e07f671664832f90b11b5f2c8db06f